### PR TITLE
fix(deps): bump fast-xml-builder to 1.2.0 (CVE-2026-44665)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "weighttracker",
       "version": "1.0.0",
       "hasInstallScript": true,
       "license": "ISC",
@@ -3352,9 +3353,9 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -3364,7 +3365,8 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -6003,6 +6005,7 @@
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
       "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6439,7 +6442,6 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
       "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -7691,6 +7693,22 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/y18n": {


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #378 / [GHSA-5wm8-gmm8-39j9](https://github.com/advisories/GHSA-5wm8-gmm8-39j9) (HIGH severity, CVE-2026-44665)
- `fast-xml-builder` is a transitive dep of `fast-xml-parser`; `npm update fast-xml-builder --package-lock-only` bumped it from `1.1.4` → `1.2.0` (patched version is `1.1.7`)
- Pulls in one new transitive: `xml-naming@0.1.0` (same NaturalIntelligence maintainer as the rest of the fast-xml-* family)
- `package.json` unchanged — lockfile-only patch

## Notes
- Cosmetic noise in the diff: `prop-types` / `scheduler` peer flags flipped due to npm 11.6.2 recomputing peer-dep metadata. Not a behavior change.
- This repo has **26 other open Dependabot alerts** (axios ×8, undici ×7, mongoose, protobufjs, underscore, etc.). Worth a follow-up batch — see /security/dependabot.

## Test plan
- [ ] CI green
- [ ] Local `npm install` resolves cleanly
- [ ] No runtime regression in XML build paths (`fast-xml-builder` is `optional: true` and a transitive of `fast-xml-parser`)